### PR TITLE
Fix returnHome call when market fails to load

### DIFF
--- a/mexico-flight.user.js
+++ b/mexico-flight.user.js
@@ -130,6 +130,8 @@
             const marketReady = await waitForSelector('a.buy', 8000, 200);
             if (!marketReady) {
                 log('❌ Market not loaded—skipping buys');
+                returnHome();
+                sessionStorage.removeItem(FLIGHT_FLAG);
                 return;
             }
 
@@ -158,6 +160,8 @@
                 const marketReady = await waitForSelector('a.buy', 8000, 200);
                 if (!marketReady) {
                     log('❌ Market not loaded—skipping buys');
+                    returnHome();
+                    sessionStorage.removeItem(FLIGHT_FLAG);
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- handle market load failures by returning home
- apply same fix during reload resume

## Testing
- `node -c mexico-flight.user.js`

------
https://chatgpt.com/codex/tasks/task_e_685d1dcc5ffc8330baf689c31b738c96